### PR TITLE
Highlight VACUUM FULL TABLE keywords

### DIFF
--- a/root/.config/nvim/syntax/gsqlterm.vim
+++ b/root/.config/nvim/syntax/gsqlterm.vim
@@ -29,13 +29,13 @@ syntax keyword gsqlDml contained
       \ select insert update delete merge replace copy
 
 syntax keyword gsqlDdl contained
-      \ create alter drop truncate rename comment grant revoke
+      \ create alter drop truncate rename comment grant revoke vacuum
 
 syntax keyword gsqlTxn contained
       \ begin start commit rollback savepoint release transaction
 
 syntax keyword gsqlClause contained
-      \ from where group by having order limit offset
+      \ from where group by having order limit offset table
       \ into values set returning
       \ join inner left right full outer cross on using
       \ union intersect except all distinct


### PR DESCRIPTION
### Motivation
- Ensure `VACUUM FULL TABLE` statements are properly highlighted in the gsqlterm syntax file so these maintenance commands are visually emphasized like other DDL and clause keywords.

### Description
- Add `vacuum` to the `gsqlDdl` keyword group in `root/.config/nvim/syntax/gsqlterm.vim`.
- Add `table` to the `gsqlClause` keyword group in the same file so the sequence `vacuum full table` is fully highlighted.

### Testing
- Ran `git diff --check` to validate the patch formatting, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e7b6fa22c832a82001c5d40a4dd2f)