### PR TITLE
Add :TmuxSend command and pane_identifier support for tmux prompt sending

### DIFF
--- a/root/.config/nvim/lua/plugins/tmux.lua
+++ b/root/.config/nvim/lua/plugins/tmux.lua
@@ -185,10 +185,32 @@ local function send_to_tmux_pane()
 	vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<esc>", true, false, true), "x", true)
 end
 
+local pane_identifier = "run `:TmuxSend %id` first!"
+vim.api.nvim_create_user_command("TmuxSend", function(opts)
+	pane_identifier = opts.args
+	print("pane_identifier = " .. pane_identifier)
+end, {
+	nargs = 1,
+})
+
 local function send_prompt_to_tmux_pane(input)
-	require("tmux_send").send_to_pane({ count_is_uid = true, content = require("sidekick.cli").render(input) })
-	-- (Optional) exit visual mode after sending
-	vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<esc>", true, false, true), "x", true)
+	local opts = {
+		content = require("sidekick.cli").render(input),
+		add_newline = false,
+	}
+
+	if vim.v.count > 0 then
+		opts.count_is_uid = true
+	else
+		opts.pane_identifier = pane_identifier
+	end
+
+	require("tmux_send").send_to_pane(opts)
+	vim.api.nvim_feedkeys(
+		vim.api.nvim_replace_termcodes("<esc>", true, false, true),
+		"x",
+		true
+	)
 end
 return {
 	{


### PR DESCRIPTION
### Motivation
- Allow configuring a specific tmux pane target for sending rendered prompts when a numeric count is not provided.
- Ensure Sidekick-rendered prompts are sent without an implicit trailing newline and that visual mode is exited after sending.

### Description
- Introduce a `pane_identifier` default message and a `:TmuxSend` user command that sets `pane_identifier` from the command argument and prints the value.
- Replace the previous `send_prompt_to_tmux_pane` implementation with logic that builds an `opts` table containing `content = require("sidekick.cli").render(input)` and `add_newline = false`.
- When `vim.v.count > 0`, set `opts.count_is_uid = true`, otherwise set `opts.pane_identifier = pane_identifier`, then call `require("tmux_send").send_to_pane(opts)`.
- Preserve exiting visual mode after sending by calling `vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<esc>", true, false, true), "x", true)`.

### Testing
- Ran `git diff --check` which produced no whitespace errors or issues.
- Attempted `luac -p root/.config/nvim/lua/plugins/tmux.lua` but `luac` is not available in the environment, so a Lua bytecode/syntax validation could not be performed here.
- Verified the edited file content and surrounding context with a line-range print to confirm the inserted block and function replacement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27dad6cf30832ab14b95245eb73c5f)